### PR TITLE
Fix error checking when when a device does not support GL_UNSIGNED_INT

### DIFF
--- a/engine/src/main/java/org/andresoviedo/android_3d_model_engine/drawer/GLES20Renderer.java
+++ b/engine/src/main/java/org/andresoviedo/android_3d_model_engine/drawer/GLES20Renderer.java
@@ -398,8 +398,8 @@ class GLES20Renderer implements Renderer {
                 drawOrderBuffer.position(0);
                 GLES20.glDrawElements(drawMode, drawOrderBuffer.capacity(), drawBufferType,
                         drawOrderBuffer);
-                GLUtil.checkGlError("glDrawElements");
-                if (drawUsingUnsignedInt && GLUtil.checkGlError("glDrawElements")) {
+                boolean error = GLUtil.checkGlError("glDrawElements");
+                if (drawUsingUnsignedInt && error) {
                     drawUsingUnsignedInt = false;
                 }
             }*/
@@ -438,8 +438,8 @@ class GLES20Renderer implements Renderer {
                 drawOrderBuffer.position(0);
                 GLES20.glDrawElements(drawMode, drawOrderBuffer.capacity(), drawBufferType,
                         drawOrderBuffer);
-                GLUtil.checkGlError("glDrawElements");
-                if (drawUsingUnsignedInt && GLUtil.checkGlError("glDrawElements")) {
+                boolean error = GLUtil.checkGlError("glDrawElements");
+                if (drawUsingUnsignedInt && error) {
                     drawUsingUnsignedInt = false;
                 }
 
@@ -455,10 +455,10 @@ class GLES20Renderer implements Renderer {
             for (int i = 0; i < drawOrderBuffer.capacity(); i += drawSize) {
                 drawOrderBuffer.position(i);
                 GLES20.glDrawElements(drawMode, drawSize, drawBufferType, drawOrderBuffer);
-                GLUtil.checkGlError("glDrawElements");
-            }
-            if (drawUsingUnsignedInt && GLUtil.checkGlError("glDrawElements")) {
-                drawUsingUnsignedInt = false;
+                boolean error = GLUtil.checkGlError("glDrawElements");
+                if (drawUsingUnsignedInt && error) {
+                    drawUsingUnsignedInt = false;
+                }
             }
         }
     }
@@ -472,8 +472,8 @@ class GLES20Renderer implements Renderer {
             int drawSizePolygon = drawPart[2];
             drawOrderBuffer.position(vertexPos);
             GLES20.glDrawElements(drawModePolygon, drawSizePolygon, drawBufferType, drawOrderBuffer);
-            GLUtil.checkGlError("glDrawElements");
-            if (drawUsingUnsignedInt && GLUtil.checkGlError("glDrawElements")) {
+            boolean error = GLUtil.checkGlError("glDrawElements");
+            if (drawUsingUnsignedInt && error) {
                 drawUsingUnsignedInt = false;
             }
         }

--- a/engine/src/main/java/org/andresoviedo/android_3d_model_engine/drawer/GLES20Renderer.java
+++ b/engine/src/main/java/org/andresoviedo/android_3d_model_engine/drawer/GLES20Renderer.java
@@ -9,9 +9,12 @@ import org.andresoviedo.android_3d_model_engine.model.AnimatedModel;
 import org.andresoviedo.android_3d_model_engine.model.Element;
 import org.andresoviedo.android_3d_model_engine.model.Object3DData;
 import org.andresoviedo.util.android.GLUtil;
+import org.andresoviedo.util.io.IOUtils;
 
 import java.nio.Buffer;
 import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -416,6 +419,7 @@ class GLES20Renderer implements Renderer {
                 Element element = obj.getElements().get(i);
                 drawOrderBuffer = element.getIndexBuffer();
 
+
                 // log event
                 if (id != flags.get(element)) {
                     Log.v("GLES20Renderer", "Rendering element " + i + "....  " + element);
@@ -427,10 +431,22 @@ class GLES20Renderer implements Renderer {
                 if (element.getMaterial() != null) {
                     if (!supportsColors()) {
                         setUniform4(element.getMaterial().getColor() != null ? element.getMaterial().getColor() :
-                                obj.getColor() != null? obj.getColor() : DEFAULT_COLOR, "vColor");
+                                obj.getColor() != null ? obj.getColor() : DEFAULT_COLOR, "vColor");
                     }
                     if (element.getMaterial().getTextureId() != -1 && supportsTextures()) {
                         setTexture(element.getMaterial().getTextureId());
+                    }
+                }
+
+                if(drawUsingUnsignedInt == false){
+                    ShortBuffer indexShortBuffer = null;
+                    drawOrderBuffer.position(0);
+                    if (indexShortBuffer == null && drawOrderBuffer != null) {
+                        indexShortBuffer = IOUtils.createShortBuffer(((IntBuffer) drawOrderBuffer).capacity());
+                        for (int j = 0; j < indexShortBuffer.capacity(); j++) {
+                            indexShortBuffer.put((short) ((IntBuffer) drawOrderBuffer).get(j));
+                        }
+                        drawOrderBuffer = indexShortBuffer;
                     }
                 }
 


### PR DESCRIPTION
Error checking for drawUsingUnsignedInt wasn't working as GLUtil.checkGlError("glDrawElements"); was being called twice in a row.